### PR TITLE
Fix error in README install step description

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ In the [repository](https://github.com/MasDevProject/ng2-bs-dialogs-creator.git)
 
 Use `npm` to download tha library.
 ```
-npm install ng2-bs-dialogs
+npm install ng2-bs-dialogs-creator
 ```
 
 


### PR DESCRIPTION
The installation instructions from README are not up to date, as it seems that npm package name has changed.